### PR TITLE
Let UserResolver#user_info_by_id return nil on user_not_found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+
+- Let UserResolver#user_info_by_id return nil on user_not_found error (https://github.com/tomoasleep/ruboty-slack_events/pull/2)
+
 ## 0.3.0 - 2025-04-04
 
 - Rewrite text filter to parse links and unescape HTML entities

--- a/lib/ruboty/slack_events/resolvers/user_resolver.rb
+++ b/lib/ruboty/slack_events/resolvers/user_resolver.rb
@@ -34,6 +34,9 @@ module Ruboty
             Logger.debug { "Slack API: users.info(#{user_id})" }
             res = slack_client.users_info(user: user_id)
             res.user
+          rescue Slack::Web::Api::Errors::UserNotFound => e
+            Logger.debug { "Slack API Error: users.info(#{user_id}) => #{e.message}" }
+            nil
           end
         end
 


### PR DESCRIPTION
This PR resolves https://github.com/tomoasleep/ruboty-slack_events/issues/1

[users.info](https://api.slack.com/methods/users.info) may raises `user_not_found` error when the name is wrong. Treat these errors as nil.

## Ref

* https://github.com/yasslab/ruboty-slack_events/commit/0718db83c1a5b2ca8f7370379396bc0d7886a7ab