### PR TITLE
Stringify text message

### DIFF
--- a/lib/ruboty/adapters/slack_events.rb
+++ b/lib/ruboty/adapters/slack_events.rb
@@ -43,7 +43,7 @@ module Ruboty
               ```
             MARKDOWN
           else
-            slackify.call(message[:body])
+            slackify.call(message[:body].to_s)
           end
 
         slack_client.chat_postMessage(


### PR DESCRIPTION
# What

Closes https://github.com/tomoasleep/ruboty-slack_events/issues/3

- stringify text message, to allow to pass argument having `.to_s` object.

